### PR TITLE
Add FR_IGNORE_NAMES (#91)

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -119,6 +119,12 @@ if (!defined('FR_OIDC_DEBUG')) {
         define('FR_OIDC_DEBUG', false);
     }
 }
+// Optional: which file or directory names to ignore while indexing
+// Set FR_IGNORE_NAMES to a comma-separated list of file or directory names to ignore.
+if (!defined('FR_IGNORE_NAMES')) {
+    $envVal = getenv('FR_IGNORE_NAMES');
+    define('FR_IGNORE_NAMES', ($envVal !== false && $envVal !== '') ? $envVal : '@eaDir,#recycle,.DS_Store,Thumbs.db');
+}
 // Optional: trusted proxy IP resolution for rate limiting/logging
 // Set FR_TRUSTED_PROXIES to a comma-separated list of IPs/CIDRs (e.g. "127.0.0.1,10.0.0.0/8").
 if (!defined('FR_TRUSTED_PROXIES')) {

--- a/src/lib/FS.php
+++ b/src/lib/FS.php
@@ -9,7 +9,25 @@ final class FS
 {
     /** Hidden/system names to ignore entirely */
     public static function IGNORE(): array {
-        return ['@eaDir', '#recycle', '.DS_Store', 'Thumbs.db'];
+        $raw = '';
+        if (defined('FR_IGNORE_NAMES')) {
+            $raw = FR_IGNORE_NAMES;
+        } else {
+            $env = getenv('FR_IGNORE_NAMES');
+            if ($env !== false && $env !== '') {
+                $raw = $env;
+            }
+        }
+
+        if (is_array($raw)) {
+            return $raw;
+        }
+        if (!is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $parts = array_map('trim', explode(',', $raw));
+        return array_values(array_filter($parts, fn($part) => $part !== ''));
     }
 
     /** App-specific names to skip from UI */


### PR DESCRIPTION
Adding this should enable users to specify what directories to ignore so that their indexing doesn't take too long or consume too much resources or possibly to hide even more metadata files (ie. ``.DS_store``)

~~I haven't been able to test this due to the fact that I couldn't get the CI to run. Docker is giving me trouble, but I assume it should be correct because its quite literally the same method you used for ``FR_TRUSTED_PROXIES``.~~

~~Anyway please test if you can and merge it it seems right.~~

Update: This doesn't seem to work. I don't know why.