### PR TITLE
Guard disk_free_space() and disk_total_space() with function_exists()

### DIFF
--- a/src/FileRise/Domain/DiskUsageModel.php
+++ b/src/FileRise/Domain/DiskUsageModel.php
@@ -632,8 +632,8 @@ class DiskUsageModel
                 continue;
             }
 
-            $total = @disk_total_space($real);
-            $free  = @disk_free_space($real);
+            $total = function_exists('disk_total_space') ? @disk_total_space($real) : false;
+            $free  = function_exists('disk_free_space') ? @disk_free_space($real) : false;
             if ($total === false || $free === false || $total <= 0) {
                 continue;
             }

--- a/src/FileRise/Domain/FileModel.php
+++ b/src/FileRise/Domain/FileModel.php
@@ -1616,7 +1616,7 @@ class FileModel
                 $totalSize += (int)$sz;
             }
         }
-        $free = @disk_free_space($work);
+        $free = function_exists('disk_free_space') ? @disk_free_space($work) : false;
         // Add ~20MB overhead and a 5% cushion
         if ($free !== false && $totalSize > 0) {
             $needed = (int)ceil($totalSize * 1.05) + (20 * 1024 * 1024);

--- a/src/FileRise/Http/Controllers/FolderController.php
+++ b/src/FileRise/Http/Controllers/FolderController.php
@@ -2149,7 +2149,7 @@ class FolderController
         }
 
         // Ensure enough free space (best-effort)
-        $free = @disk_free_space($work);
+        $free = function_exists('disk_free_space') ? @disk_free_space($work) : false;
         if ($free !== false && $totalBytes > 0) {
             $needed = (int)ceil($totalBytes * 1.05) + (20 * 1024 * 1024);
             if ($free < $needed) {


### PR DESCRIPTION
`FileModel::createZipArchive()` and `FolderController` call `disk_free_space()` without checking whether the function exists. This causes a fatal error on hosts where the function is in `disable_functions`. The fix wraps the call:

```php
$free = function_exists('disk_free_space') ? @disk_free_space($work) : false;
```

The same fix is needed in `DiskUsageModel` and in the admin panel disk usage display.

The same guard should be applied to any other host-restricted functions called without `function_exists()` checks.