### PR TITLE
Create documentation about keyboard shortcuts

### DIFF
--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -51,6 +51,7 @@ FileRise is built around a few simple principles:
 - [Pro Sources](https://filerise.net/docs/?page=pro-sources)
 - [Developer guide](https://github.com/error311/FileRise/wiki/Developer-Guide)
 - [Screenshots](https://github.com/error311/FileRise/wiki/Screenshots)
+- [Keyboard shortcuts](https://github.com/error311/FileRise/wiki/Keyboard)
 
 ## Pro
 

--- a/docs/wiki/Keyboard.md
+++ b/docs/wiki/Keyboard.md
@@ -1,0 +1,22 @@
+# Keyboard shortcuts
+
+A feature of the interface is using keyboard shortcuts.
+
+Press `?` to show help for keyboard shortcuts.
+
+
+## Keys and their actions
+
+|Key            |Action    |
+|---------------|----------|
+|/              |Search    |
+|?              |Help      |
+|Del            |Delete    |
+|F2             |Rename    |
+|F3             |Preview   |
+|F4             |Edit      |
+|F5             |Copy      |
+|F6             |Move      |
+|F7             |New folder|
+|F8             |Delete    |
+|Ctrl/Cmd+Shit+N|New folder|


### PR DESCRIPTION
I had difficulty finding information about the keyboard shortcuts. This became problematic when I tried pressing F5 to refresh the interface.

This PR adds a wiki page documenting the keyboard shortcuts, named `Keyboard.md`.